### PR TITLE
Update to embedded-hal 1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,23 @@ version = "0.1.0"
 authors = ["Michael Böckling <michael@boeckling.net>"]
 repository = "https://github.com/MrBuddyCasino/mcp9808-rs"
 categories = ["embedded", "hardware-support", "no-std"]
-keywords = ["embedded-hal-driver", "microchip", "driver", "temperature", "sensor"]
+keywords = [
+    "embedded-hal-driver",
+    "microchip",
+    "driver",
+    "temperature",
+    "sensor",
+]
 license = "MIT OR Apache-2.0"
 description = "Platform agnostic Rust driver for the Microchip MCP9808 temperature sensor."
 readme = "README.md"
 
 [dependencies]
-embedded-hal = "0.1.2"
-bit_field = "0.9.0"
+embedded-hal = "0.2.7"
+bit_field = "0.10.2"
 
 [dependencies.cast]
-version = "0.2.2"
+version = "0.3.0"
 default-features = false
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp9808"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Michael Böckling <michael@boeckling.net>"]
 repository = "https://github.com/MrBuddyCasino/mcp9808-rs"
 categories = ["embedded", "hardware-support", "no-std"]
@@ -21,7 +21,7 @@ with_floating_point = []
 no_floating_point = []
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = { version = "1.0.0-rc.1" }
 bit_field = "0.10.2"
 
 [dependencies.cast]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp9808"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Michael Böckling <michael@boeckling.net>"]
 repository = "https://github.com/MrBuddyCasino/mcp9808-rs"
 categories = ["embedded", "hardware-support", "no-std"]
@@ -14,6 +14,11 @@ keywords = [
 license = "MIT OR Apache-2.0"
 description = "Platform agnostic Rust driver for the Microchip MCP9808 temperature sensor."
 readme = "README.md"
+
+[features]
+default = ["with_floating_point"]
+with_floating_point = []
+no_floating_point = []
 
 [dependencies]
 embedded-hal = "0.2.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+/// All possible errors in this crate
+#[derive(Debug)]
+pub enum Error<E> {
+    /// I2C bus error
+    I2c(E),
+    RegisterSizeMismatch(u8),
+}
+impl<E> From<E> for Error<E> {
+    fn from(other: E) -> Self {
+        Error::I2c(other)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,20 @@
 
 extern crate bit_field;
 extern crate cast;
-extern crate embedded_hal as hal;
+extern crate embedded_hal;
 
-use hal::blocking::i2c;
-use reg_conf::Configuration;
-use reg_device_id::DeviceId;
-use reg_manuf_id::ManufacturerId;
-use reg_res::Resolution;
-use reg_temp::Temperature;
-use reg_temp_alert_crit::CriticalTemperatureAlert;
-use reg_temp_alert_lower::LowerTemperatureAlert;
-use reg_temp_alert_upper::UpperTemperatureAlert;
+use crate::error::Error;
+use crate::reg_conf::Configuration;
+use crate::reg_device_id::DeviceId;
+use crate::reg_manuf_id::ManufacturerId;
+use crate::reg_res::Resolution;
+use crate::reg_temp::Temperature;
+use crate::reg_temp_alert_crit::CriticalTemperatureAlert;
+use crate::reg_temp_alert_lower::LowerTemperatureAlert;
+use crate::reg_temp_alert_upper::UpperTemperatureAlert;
+use embedded_hal::i2c::{I2c, SevenBitAddress};
 
+pub mod error;
 mod prelude;
 pub mod reg;
 pub mod reg_conf;
@@ -33,23 +35,16 @@ pub enum Address {
     Default = 0b0011000,
 }
 
-/// All possible errors in this crate
-#[derive(Debug)]
-pub enum Error<E> {
-    /// I2C bus error
-    I2c(E),
-    RegisterSizeMismatch(u8),
-}
-
 /// MCP9808 Driver
 pub struct MCP9808<I2C> {
     addr: u8,
     i2c: I2C,
 }
 
-impl<I2C, E> MCP9808<I2C>
+impl<I2C> MCP9808<I2C>
 where
-    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: I2c<SevenBitAddress>,
+    I2C::Error: Into<Error<I2C::Error>>,
 {
     /// Creates a new driver from an I2C peripheral.
     pub fn new(i2c: I2C) -> Self {
@@ -64,52 +59,53 @@ where
         self.i2c
     }
 
-    fn read_register<T>(&mut self, mut reg: T) -> Result<T, Error<E>>
+    fn read_register<T>(&mut self, mut reg: T) -> Result<T, Error<I2C::Error>>
     where
         T: prelude::Read,
-        I2C: i2c::WriteRead,
+        I2C: I2c<SevenBitAddress>,
+        I2C::Error: Into<Error<I2C::Error>>,
     {
-        reg.read_from_device(&mut self.i2c, self.addr)
-            .map_err(Error::I2c)?;
+        reg.read_from_device(&mut self.i2c, self.addr)?;
         Ok(reg)
     }
 
-    pub fn write_register<R: prelude::Write>(&mut self, reg: R) -> Result<(), Error<E>> {
-        reg.write_to_device(&mut self.i2c, self.addr)
-            .map_err(Error::I2c)?;
+    pub fn write_register<R: prelude::Write>(&mut self, reg: R) -> Result<(), Error<I2C::Error>> {
+        reg.write_to_device(&mut self.i2c, self.addr)?;
         Ok(())
     }
 
-    pub fn read_configuration(&mut self) -> Result<impl Configuration, Error<E>> {
+    pub fn read_configuration(&mut self) -> Result<impl Configuration, Error<I2C::Error>> {
         self.read_register(reg_conf::new())
     }
 
-    pub fn read_device_id(&mut self) -> Result<impl DeviceId, Error<E>> {
+    pub fn read_device_id(&mut self) -> Result<impl DeviceId, Error<I2C::Error>> {
         self.read_register(reg_device_id::new())
     }
 
-    pub fn read_manufacturer_id(&mut self) -> Result<impl ManufacturerId, Error<E>> {
+    pub fn read_manufacturer_id(&mut self) -> Result<impl ManufacturerId, Error<I2C::Error>> {
         self.read_register(reg_manuf_id::new())
     }
 
-    pub fn read_resolution(&mut self) -> Result<impl Resolution, Error<E>> {
+    pub fn read_resolution(&mut self) -> Result<impl Resolution, Error<I2C::Error>> {
         self.read_register(reg_res::new())
     }
 
     /// Read temperature register. Its double-buffered so no wait required.
-    pub fn read_temperature(&mut self) -> Result<impl Temperature, Error<E>> {
+    pub fn read_temperature(&mut self) -> Result<impl Temperature, Error<I2C::Error>> {
         self.read_register(reg_temp::new())
     }
 
-    pub fn read_alert_critical(&mut self) -> Result<impl CriticalTemperatureAlert, Error<E>> {
+    pub fn read_alert_critical(
+        &mut self,
+    ) -> Result<impl CriticalTemperatureAlert, Error<I2C::Error>> {
         self.read_register(reg_temp_alert_crit::new())
     }
 
-    pub fn read_alert_lower(&mut self) -> Result<impl LowerTemperatureAlert, Error<E>> {
+    pub fn read_alert_lower(&mut self) -> Result<impl LowerTemperatureAlert, Error<I2C::Error>> {
         self.read_register(reg_temp_alert_lower::new())
     }
 
-    pub fn read_alert_upper(&mut self) -> Result<impl UpperTemperatureAlert, Error<E>> {
+    pub fn read_alert_upper(&mut self) -> Result<impl UpperTemperatureAlert, Error<I2C::Error>> {
         self.read_register(reg_temp_alert_upper::new())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(conservative_impl_trait, universal_impl_trait)]
-//#![feature(trait_alias)]
-#![feature(core_float)]
-
 #![deny(warnings)]
 #![no_std]
 
@@ -13,14 +9,13 @@ use hal::blocking::i2c;
 use reg_conf::Configuration;
 use reg_device_id::DeviceId;
 use reg_manuf_id::ManufacturerId;
-use reg_temp::Temperature;
 use reg_res::Resolution;
+use reg_temp::Temperature;
 use reg_temp_alert_crit::CriticalTemperatureAlert;
 use reg_temp_alert_lower::LowerTemperatureAlert;
 use reg_temp_alert_upper::UpperTemperatureAlert;
 
 mod prelude;
-pub mod reg_temp_generic;
 pub mod reg;
 pub mod reg_conf;
 pub mod reg_device_id;
@@ -30,12 +25,12 @@ pub mod reg_temp;
 pub mod reg_temp_alert_crit;
 pub mod reg_temp_alert_lower;
 pub mod reg_temp_alert_upper;
-
+pub mod reg_temp_generic;
 
 /// I2C address
 #[derive(Clone, Copy)]
 pub enum Address {
-    Default = 0b0011000
+    Default = 0b0011000,
 }
 
 /// All possible errors in this crate
@@ -52,10 +47,9 @@ pub struct MCP9808<I2C> {
     i2c: I2C,
 }
 
-
 impl<I2C, E> MCP9808<I2C>
-    where I2C: i2c::Write<Error=E> + i2c::WriteRead<Error=E>
-
+where
+    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
 {
     /// Creates a new driver from an I2C peripheral.
     pub fn new(i2c: I2C) -> Self {
@@ -71,14 +65,18 @@ impl<I2C, E> MCP9808<I2C>
     }
 
     fn read_register<T>(&mut self, mut reg: T) -> Result<T, Error<E>>
-        where T: prelude::Read,
-              I2C: i2c::WriteRead {
-        reg.read_from_device(&mut self.i2c, self.addr).map_err(Error::I2c)?;
+    where
+        T: prelude::Read,
+        I2C: i2c::WriteRead,
+    {
+        reg.read_from_device(&mut self.i2c, self.addr)
+            .map_err(Error::I2c)?;
         Ok(reg)
     }
 
     pub fn write_register<R: prelude::Write>(&mut self, reg: R) -> Result<(), Error<E>> {
-        reg.write_to_device(&mut self.i2c, self.addr).map_err(Error::I2c)?;
+        reg.write_to_device(&mut self.i2c, self.addr)
+            .map_err(Error::I2c)?;
         Ok(())
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,38 +1,52 @@
-use hal::blocking::i2c;
+use crate::error::Error;
+use crate::reg::Register;
 use core::fmt::Debug;
-use reg::Register;
+use embedded_hal::i2c::{I2c, SevenBitAddress};
 
 /// trait for a register that can be read from an i2c device
 pub trait Read: Debug + Copy + Clone {
-    fn read_from_device<I2C, E>(&mut self, i2c: &mut I2C, addr: u8) -> Result<(), E>
-        where I2C: i2c::WriteRead<Error=E>;
+    fn read_from_device<I2C>(&mut self, i2c: &mut I2C, addr: u8) -> Result<(), Error<I2C::Error>>
+    where
+        I2C: I2c<SevenBitAddress>,
+        I2C::Error: Into<Error<I2C::Error>>;
 }
 
 impl Read for Register {
-    fn read_from_device<I2C, E>(&mut self, i2c: &mut I2C, addr: u8) -> Result<(), E>
-        where I2C: i2c::WriteRead<Error=E> {
+    fn read_from_device<I2C>(&mut self, i2c: &mut I2C, addr: u8) -> Result<(), Error<I2C::Error>>
+    where
+        I2C: I2c<SevenBitAddress>,
+        I2C::Error: Into<Error<I2C::Error>>,
+    {
         let mut buf = [0u8; 2];
-        i2c.write_read(addr, &[self.get_ptr()], &mut buf[0..self.get_len() as usize])?;
+        i2c.write_read(
+            addr,
+            &[self.get_ptr()],
+            &mut buf[0..self.get_len() as usize],
+        )?;
         self.set_buf(buf);
         Ok(())
     }
 }
 
-
 /// trait for a register that can be written to an i2c device
 pub trait Write: Read {
-    fn write_to_device<I2C, E>(&self, i2c: &mut I2C, addr: u8) -> Result<(), E>
-        where I2C: i2c::Write<Error=E>;
+    fn write_to_device<I2C>(&self, i2c: &mut I2C, addr: u8) -> Result<(), Error<I2C::Error>>
+    where
+        I2C: I2c<SevenBitAddress>,
+        I2C::Error: Into<Error<I2C::Error>>;
 }
 
 impl Write for Register {
-    fn write_to_device<I2C, E>(&self, i2c: &mut I2C, addr: u8) -> Result<(), E>
-        where I2C: i2c::Write<Error=E> {
+    fn write_to_device<I2C>(&self, i2c: &mut I2C, addr: u8) -> Result<(), Error<I2C::Error>>
+    where
+        I2C: I2c<SevenBitAddress>,
+        I2C::Error: Into<Error<I2C::Error>>,
+    {
         // reg ptr + 1 or 2 bytes
         let mut buf = [self.get_ptr(); 3];
         for (i, item) in self.get_buf().iter().enumerate() {
             buf[i + 1] = *item;
         }
-        i2c.write(addr, &buf[0..self.get_len() as usize])
+        Ok(i2c.write(addr, &buf[0..self.get_len() as usize])?)
     }
 }

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -10,7 +10,6 @@ pub struct Register {
     len: u8,
 }
 
-
 impl Register {
     pub fn new(ptr: u8, len: u8) -> Self {
         if ptr == 0 || ptr > 0b1000u8 {
@@ -68,9 +67,9 @@ impl Register {
         }
 
         if offset > 7 {
-            return self.get_msb().get_bit(offset - 8);
+            self.get_msb().get_bit(offset - 8)
         } else {
-            return self.get_lsb().unwrap().get_bit(offset);
+            self.get_lsb().unwrap().get_bit(offset)
         }
     }
 
@@ -93,12 +92,14 @@ impl Register {
 
     pub fn as_u16(&self) -> u16 {
         let (lo, hi) = (self.get_lsb(), self.get_msb());
-        if lo.is_none() { return self.get_msb() as u16; }
+        if lo.is_none() {
+            return self.get_msb() as u16;
+        }
         ((hi as u16) << 8) + (lo.unwrap() as u16)
     }
 }
 
-
+#[allow(clippy::bool_assert_comparison)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/reg_conf.rs
+++ b/src/reg_conf.rs
@@ -1,6 +1,6 @@
 use bit_field::BitField;
-use reg::Register;
 use prelude::Write;
+use reg::Register;
 
 /// Alert Output Mode bit
 /// This bit cannot be altered when either of the Lock bits are set (bit 6 and bit 7).
@@ -243,6 +243,7 @@ impl Configuration for Register {
         self.set_bit(8, bool(mode as isize));
     }
 
+    #[allow(unused_must_use, clippy::unnecessary_operation)] // TODO: address these allows
     fn set_hysteresis(&mut self, mode: Hysteresis) {
         &self.set_bit(9, (mode as i64).get_bit(0));
         &self.set_bit(10, (mode as i64).get_bit(1));
@@ -255,7 +256,7 @@ impl Configuration for Register {
             val if val == Hysteresis::Deg_1_5C as u8 => Hysteresis::Deg_1_5C,
             val if val == Hysteresis::Deg_3_0C as u8 => Hysteresis::Deg_3_0C,
             val if val == Hysteresis::Deg_6_0C as u8 => Hysteresis::Deg_6_0C,
-            _ => panic!("invalid value")
+            _ => panic!("invalid value"),
         }
     }
 }
@@ -264,7 +265,6 @@ impl Configuration for Register {
 fn bool(val: isize) -> bool {
     val != 0
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/reg_temp.rs
+++ b/src/reg_temp.rs
@@ -30,12 +30,11 @@ impl Temperature for Register {
     }
 }
 
-
+#[allow(clippy::bool_assert_comparison)]
 #[cfg(test)]
 mod tests {
     /// prevent auto-format fuckup
     use super::*;
-
 
     #[test]
     fn alert_critical() {

--- a/src/reg_temp_generic.rs
+++ b/src/reg_temp_generic.rs
@@ -1,8 +1,11 @@
 extern crate cast;
 
+#[cfg(feature = "with_floating_point")]
 use cast::f32;
-use cast::i16;
+#[cfg(feature = "with_floating_point")]
 use core::f32;
+
+use cast::i16;
 use prelude::Read;
 use prelude::Write;
 use reg::Register;
@@ -20,6 +23,7 @@ const BIT_SIGN: u8 = 0x10;
 /// bit 1-0 Unimplemented: Read as ‘0
 pub trait ReadableTempRegister: Read {
     /// degree celcius as float
+    #[cfg(feature = "with_floating_point")]
     fn get_celcius(&self, res: ResolutionVal) -> f32;
 
     /// avoids floats, but only works up to 0.125 resolution
@@ -30,6 +34,7 @@ pub trait ReadableTempRegister: Read {
 }
 
 impl ReadableTempRegister for Register {
+    #[cfg(feature = "with_floating_point")]
     fn get_celcius(&self, res: ResolutionVal) -> f32 {
         let high = self.get_msb() & 0x1f; // clear flags
         let low: u8 = self.get_lsb().unwrap();
@@ -59,11 +64,14 @@ impl ReadableTempRegister for Register {
 }
 
 pub trait WritableTempRegister: ReadableTempRegister + Write {
+    #[cfg(feature = "with_floating_point")]
     fn set_celcius(&mut self, val: f32);
+
     fn set_milli_celcius(&mut self, val: i32);
 }
 
 impl WritableTempRegister for Register {
+    #[cfg(feature = "with_floating_point")]
     fn set_celcius(&mut self, val: f32) {
         if val >= f32(RANGE_LIMIT) || val <= -f32(RANGE_LIMIT) {
             panic!(
@@ -136,6 +144,7 @@ fn get_fractional_part_dec(res: ResolutionVal, low: u8) -> u16 {
     (fract >> (3 - res as u16)) * get_precision_factor_dec(res)
 }
 
+#[cfg(feature = "with_floating_point")]
 fn get_fractional_part_float(res: ResolutionVal, low: u8) -> f32 {
     let fract = low & 0x000F; // mask nibble
     f32(fract >> (3 - res as u8)) * get_precision_factor_float(res)
@@ -144,6 +153,7 @@ fn get_fractional_part_float(res: ResolutionVal, low: u8) -> f32 {
 //fn set_fractional_part_float(res: ResolutionVal, val: f32) {}
 //fn set_fractional_part_dec(res: ResolutionVal, val: i32) {}
 
+#[cfg(feature = "with_floating_point")]
 fn get_precision_factor_float(res: ResolutionVal) -> f32 {
     match res {
         ResolutionVal::Deg_0_0625C => 0.0625,


### PR DESCRIPTION
Updates to the new embedded-hal release candidate, which has breaking changes in the I2C interface.
- Updates the minor revision to reflect the breaking interface change.
- Segregates operations using floating point numbers into its own feature (with_floating_point is default.)
- Several changes made to support current compiler, especially removing obsolete feature inclusion.
-  Changes Rust edition to 2021.